### PR TITLE
#1 - Enhance URL creation logic to validate custom keys and handle conflicts

### DIFF
--- a/backend/crud.py
+++ b/backend/crud.py
@@ -6,13 +6,20 @@ import schemas
 
 
 def create_db_url(db: Session, url: schemas.URLBase) -> models.URL:
-    key = keygen.create_unique_random_key(db)
+    key = url.custom_key
+    if key:
+        db_url = db.query(models.URL).filter(models.URL.key == key).first()
+        if db_url:
+            raise ValueError("Custom key already exists")
+    else:
+        key = keygen.create_unique_random_key(db)
+
     secret_key = f"{key}_{keygen.create_random_key(length=8)}"
-
     db_url = models.URL(
-        target_url=url.target_url, key=key, secret_key=secret_key
+        target_url=url.target_url,
+        key=key,
+        secret_key=secret_key,
     )
-
     db.add(db_url)
     db.commit()
     db.refresh(db_url)

--- a/backend/main.py
+++ b/backend/main.py
@@ -58,7 +58,11 @@ def create_url(url: schemas.URLBase, db: Session = Depends(get_db)):
     if not validators.url(url.target_url):
         raise_bad_request(message="Your provided URL is not valid")
 
-    db_url = crud.create_db_url(db=db, url=url)
+    try:
+        db_url = crud.create_db_url(db=db, url=url)
+    except ValueError as e:
+        raise HTTPException(status_code=409, detail=str(e))
+
     return get_admin_info(db_url)
 
 

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,8 +1,11 @@
+from typing import Optional
+
 from pydantic import BaseModel
 
 
 class URLBase(BaseModel):
     target_url: str
+    custom_key: Optional[str] = None
 
 
 class URL(URLBase):
@@ -13,6 +16,12 @@ class URL(URLBase):
         orm_mode = True
 
 
-class URLInfo(URL):
+class URLInfo(BaseModel):
+    target_url: str
+    is_active: bool
+    clicks: int
     url: str
     admin_url: str
+
+    class Config:
+        orm_mode = True


### PR DESCRIPTION
This pull request introduces support for custom keys in the URL shortening service and improves error handling for key conflicts. The most important changes include adding a `custom_key` field to the schema, updating the database logic to handle custom keys, and enhancing the API to return appropriate error responses for conflicts.

### Support for custom keys:

* [`backend/schemas.py`](diffhunk://#diff-ffffbd4012472eeee22ddd8e6562335fb4edc8d1ba1d83c8db791465f607ff01R1-R8): Added an optional `custom_key` field to the `URLBase` schema to allow users to specify a custom key for shortened URLs.
* [`backend/crud.py`](diffhunk://#diff-2833ba8f04f16b19c511efe9b6d77dfb2431f9d57207a1b0d4d4af0e7e434384R9-L15): Updated the `create_db_url` function to check for conflicts when a custom key is provided. If the key already exists, a `ValueError` is raised.

### Improved error handling:

* [`backend/main.py`](diffhunk://#diff-df5184bf1f67239fcedd4578cd15b7c94f3f765feabd09c5f20b5831bca33903R61-R65): Wrapped the call to `create_db_url` in a `try-except` block to catch `ValueError` exceptions. If a custom key conflict occurs, an `HTTPException` with a 409 status code is raised.

### Schema adjustments:

* [`backend/schemas.py`](diffhunk://#diff-ffffbd4012472eeee22ddd8e6562335fb4edc8d1ba1d83c8db791465f607ff01L16-R27): Refactored the `URLInfo` schema to inherit directly from `BaseModel` instead of `URL`, and explicitly defined its fields, ensuring better separation of concerns.